### PR TITLE
Change deployment to publish npm and pip packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,17 @@ jobs:
         run: |
           make install
           make release
+
+      - name: publish npm package
+        run: |
+          cd npm
+          npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: publish pip package
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,4 +47,5 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
+          packages_dir: pip/dist/
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,15 @@
-name: tag
+name: publish package
 
 on:
   push:
-    branches:
-      - master
+    tags:
+      - *
+    tags-ignore:
+      - v*
 
 jobs:
   build:
-    name: build-and-tag
+    name: build-and-publish
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -18,37 +20,19 @@ jobs:
         with:
           python-version: '3.8.2'
 
+      - name: setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14.x'
+          registry-url: 'https://registry.npmjs.org'
+
       - name: install poetry
         uses: Gr1N/setup-poetry@v7
 
-      - name: Set SPEC_VERSION env var
-        run: echo ::set-env name=SPEC_VERSION::"v$(date -u --iso-8601=minutes | cut -c-16 | sed -e 's/[ :T\+\-]/./g')"
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+      - name: set package version
+        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
 
       - name: build terms
         run: |
           make install
           make release
-
-      - name: create release
-        id: create_release
-        uses: actions/create-release@v1
-        continue-on-error: false
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ env.SPEC_VERSION }}
-          release_name: ${{ env.SPEC_VERSION }}
-
-
-      - name: upload terms
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: dist/terms.json
-          asset_name: terms.json
-          asset_content_type: application/json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - '*'
-    tags-ignore:
-      - v*
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: publish package
 on:
   push:
     tags:
-      - *
+      - '*'
     tags-ignore:
       - v*
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,36 @@ jobs:
       - name: set package version
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
+      - name: set SPEC_VERSION env var
+        run: echo ::set-env name=SPEC_VERSION::"v$(date -u --iso-8601=minutes | cut -c-16 | sed -e 's/[ :T\+\-]/./g')-$RELEASE_VERSION"
+        env:
+          ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+
       - name: build terms
         run: |
           make install
           make release
+
+      - name: create release
+        id: create_release
+        uses: actions/create-release@v1
+        continue-on-error: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ env.RELEASE_VERSION }}
+          release_name: ${{ env.SPEC_VERSION }}
+
+      - name: upload terms
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: dist/terms.json
+          asset_name: terms.json
+          asset_content_type: application/json
 
       - name: publish npm package
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     name: build-and-publish
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: checkout
         uses: actions/checkout@v2
 
       - name: setup python
@@ -28,7 +28,7 @@ jobs:
         uses: Gr1N/setup-poetry@v7
 
       - name: set package version
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
       - name: build terms
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@
 build/
 dist/
 
+# Python packaging
+pip/covid_19_terms/terms.json
+covid_19_terms.egg-info
+
 # Python
 __pycache__
 *.pyc
@@ -21,5 +25,8 @@ __pycache__
 .venv
 **/.pytest_cache/
 
-#Node
+# Node packaging
+npm/package.json
+
+# Node
 **/node_modules

--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,11 @@ guard-%:
 install:
 	poetry install
 
-clean:
-	rm -rf dist
+build-py:
+	cd pip && python setup.py sdist
 
-release: clean
-	mkdir -p dist
-	poetry run scripts/build.py > dist/terms.json
+release:
+	poetry run scripts/build.py
+	make build-py
 
 dist: release

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,0 +1,12 @@
+# Covid 19 Terms
+
+json covid snomed codes from "COVID-19 Vaccination Codes"
+[https://hscic.kahootz.com/connect.ti/t_c_home/view?objectId=16878800](https://hscic.kahootz.com/connect.ti/t_c_home/view?objectId=16878800)
+
+# get latest terms.json
+
+```js
+const { getTerms } = require('covid-19-terms');
+
+let terms = getTerms();
+```

--- a/npm/src/index.js
+++ b/npm/src/index.js
@@ -1,0 +1,9 @@
+const path = require('path')
+const fs = require('fs')
+
+function getTerms() {
+    let termsPath = path.join(__dirname, 'terms.json')
+    return JSON.parse(fs.readFileSync(termsPath, 'utf-8'))
+}
+
+exports.getTerms = getTerms

--- a/pip/README.md
+++ b/pip/README.md
@@ -1,0 +1,12 @@
+# Covid 19 Terms
+
+json covid snomed codes from "COVID-19 Vaccination Codes"
+[https://hscic.kahootz.com/connect.ti/t_c_home/view?objectId=16878800](https://hscic.kahootz.com/connect.ti/t_c_home/view?objectId=16878800)
+
+# get latest terms.json
+
+```python
+from covid_19_terms import get_terms
+
+terms = get_terms()
+```

--- a/pip/covid_19_terms/__init__.py
+++ b/pip/covid_19_terms/__init__.py
@@ -1,0 +1,8 @@
+import os
+import json
+
+
+def get_terms():
+    terms_path = os.path.join(os.path.dirname(__file__), 'terms.json')
+    with open(terms_path, 'r') as f:
+        return json.loads(f.read())

--- a/pip/setup.py
+++ b/pip/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='covid_19_terms',
-    version=f'{os.environ["TAG_VERSION"]}',
+    version=f'{os.environ["RELEASE_VERSION"]}',
     packages=['covid_19_terms'],
     package_dir={
         'covid_19_terms': 'covid_19_terms'

--- a/pip/setup.py
+++ b/pip/setup.py
@@ -1,0 +1,14 @@
+import os
+from setuptools import setup
+
+setup(
+    name='covid_19_terms',
+    version=f'{os.environ["TAG_VERSION"]}',
+    packages=['covid_19_terms'],
+    package_dir={
+        'covid_19_terms': 'covid_19_terms'
+    },
+    package_data={
+        'covid_19_terms': ['terms.json']
+    }
+)

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -21,7 +21,7 @@ def prepare_npm_package(base_dir, all_terms):
 
     package_json = {
         'name': 'covid-19-terms',
-        'version': f'{os.environ["TAG_VERSION"]}',
+        'version': f'{os.environ["RELEASE_VERSION"]}',
         'description': 'JSON COVID SNOMED codes from "COVID-19 Vaccination Codes"',
         'main': 'dist/index.js',
         'files': [

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -2,10 +2,52 @@
 import os
 import glob
 import json
+import shutil
 
 
 def main(base_dir):
+    all_terms = build_terms(base_dir)
+    prepare_pip_package(base_dir, all_terms)
+    prepare_npm_package(base_dir, all_terms)
 
+
+def prepare_pip_package(base_dir, all_terms):
+    delete_directory(os.path.join(base_dir, 'pip', 'dist'))
+    write_json_file(os.path.join(base_dir, 'pip', 'covid_19_terms', 'terms.json'), all_terms)
+
+
+def prepare_npm_package(base_dir, all_terms):
+    delete_directory(os.path.join(base_dir, 'npm', 'dist'))
+
+    package_json = {
+        'name': 'covid-19-terms',
+        'version': f'{os.environ["TAG_VERSION"]}',
+        'description': 'JSON COVID SNOMED codes from "COVID-19 Vaccination Codes"',
+        'main': 'dist/index.js',
+        'files': [
+            'dist/*'
+        ],
+        'scripts': {},
+        'license': 'MIT'
+    }
+
+    shutil.copytree(os.path.join(base_dir, 'npm', 'src'), os.path.join(base_dir, 'npm', 'dist'))
+
+    write_json_file(os.path.join(base_dir, 'npm', 'package.json'), package_json)
+    write_json_file(os.path.join(base_dir, 'npm', 'dist', 'terms.json'), all_terms)
+
+
+def delete_directory(dir_path):
+    if os.path.isdir(dir_path):
+        shutil.rmtree(dir_path)
+
+
+def write_json_file(filepath, data):
+    with open(filepath, 'w') as f:
+        f.write(json.dumps(data, indent=2))
+
+
+def build_terms(base_dir):
     all_terms = {}
     sections_dir = os.path.join(base_dir, 'sections')
 
@@ -75,7 +117,7 @@ def main(base_dir):
 
     all_terms['products'] = products
 
-    print(json.dumps(all_terms, indent=2))
+    return all_terms
 
 
 if __name__ == "__main__":

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -3,12 +3,20 @@ import os
 import glob
 import json
 import shutil
+import re
 
 
 def main(base_dir):
     all_terms = build_terms(base_dir)
     prepare_pip_package(base_dir, all_terms)
     prepare_npm_package(base_dir, all_terms)
+
+
+def get_release_version():
+    version = f'{os.environ["RELEASE_VERSION"]}'
+    if not re.match(r'^\d+\.\d+\.\d+$', version):
+        raise Exception(f'Invalid tag name {version}. Tag name must be: number.number.number')
+    return version
 
 
 def prepare_pip_package(base_dir, all_terms):
@@ -21,7 +29,7 @@ def prepare_npm_package(base_dir, all_terms):
 
     package_json = {
         'name': 'covid-19-terms',
-        'version': f'{os.environ["RELEASE_VERSION"]}',
+        'version': get_release_version(),
         'description': 'JSON COVID SNOMED codes from "COVID-19 Vaccination Codes"',
         'main': 'dist/index.js',
         'files': [

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -8,6 +8,7 @@ import re
 
 def main(base_dir):
     all_terms = build_terms(base_dir)
+    prepare_github_release(base_dir, all_terms)
     prepare_pip_package(base_dir, all_terms)
     prepare_npm_package(base_dir, all_terms)
 
@@ -17,6 +18,12 @@ def get_release_version():
     if not re.match(r'^\d+\.\d+\.\d+$', version):
         raise Exception(f'Invalid tag name {version}. Tag name must be: number.number.number')
     return version
+
+
+def prepare_github_release(base_dir, all_terms):
+    delete_directory(os.path.join(base_dir, 'dist'))
+    os.mkdir(os.path.join(base_dir, 'dist'))
+    write_json_file(os.path.join(base_dir, 'dist', 'terms.json'), all_terms)
 
 
 def prepare_pip_package(base_dir, all_terms):


### PR DESCRIPTION
build.py now generates files for npm and pip packages.

Deployment mechanism is now triggered after creating a new tag.
The version of the package will follow the tag name. e.g. if tag name is 1.0.0, then the package version will be set to 1.0.0

new secrets needed:
NPM_TOKEN
PYPI_API_TOKEN

Did not update readme due to repositories not created yet.